### PR TITLE
Local development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@
 # Ignore secret data
 /.env
 /master.key
+*/db/
+*/application.rb
+*/configuration.rb
+*/config.ru
+*/database.rb
+*/Rakefile
+!_base/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,7 @@
 # The Docker image to run your workspace in. Defaults to gitpod/workspace-full
 image: gitpod/workspace-postgres
+tasks:
+  - command: bin/local-setup
+  - command: echo "Run bin/local-start"
+ports:
+  - port: 8080

--- a/.local-env
+++ b/.local-env
@@ -1,0 +1,7 @@
+export POSTGRES_URI=postgresql:///resources
+export POSTGRES_HOST=localhost
+export POSTGRES_USERNAME=gitpod
+export POSTGRES_PASSWORD=
+export DEPLOY_ENV=development
+export RACK_ENV=development
+export CONCURRENCY=1

--- a/_base/Rakefile
+++ b/_base/Rakefile
@@ -3,6 +3,7 @@ require "rom/sql/rake_task"
 namespace :db do
   task :setup do
     require_relative "boot"
+    require_relative "configuration"
     require_relative "database"
   end
 end

--- a/_services/postgres/docker-entrypoint-initdb.d/create-users-and-groups.sh
+++ b/_services/postgres/docker-entrypoint-initdb.d/create-users-and-groups.sh
@@ -2,8 +2,5 @@
 
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "postgres" <<-EOSQL
-  CREATE USER "application" LOGIN SUPERUSER PASSWORD 'password';
-  CREATE DATABASE "resources";
-  GRANT ALL PRIVILEGES ON DATABASE "resources" TO "application";
-EOSQL
+createuser --host=$DATABASE_HOST --username=$POSTGRES_USERNAME application
+createdb --host=$DATABASE_HOST --username=$POSTGRES_USERNAME --owner=application resources

--- a/bin/local-setup
+++ b/bin/local-setup
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source .local-env &&
+cd mtgjson-import &&
+ln -svfF ../_base/* . &&
+unlink Dockerfile &&
+git checkout -- Dockerfile &&
+bundle exec rake db:setup

--- a/bin/local-setup
+++ b/bin/local-setup
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source .local-env &&
+_services/postgres/docker-entrypoint-initdb.d/create-users-and-groups.sh &&
 cd mtgjson-import &&
 ln -svfF ../_base/db/* db/ &&
 ln -svfF ../_base/boot.rb boot.rb &&

--- a/bin/local-setup
+++ b/bin/local-setup
@@ -2,7 +2,10 @@
 
 source .local-env &&
 cd mtgjson-import &&
-ln -svfF ../_base/* . &&
-unlink Dockerfile &&
-git checkout -- Dockerfile &&
+ln -svfF ../_base/db/* db/ &&
+ln -svfF ../_base/boot.rb boot.rb &&
+ln -svfF ../_base/config.ru config.ru &&
+ln -svfF ../_base/configuration.rb configuration.rb &&
+ln -svfF ../_base/database.rb database.rb &&
+ln -svfF ../_base/Rakefile Rakefile &&
 bundle exec rake db:setup

--- a/bin/local-start
+++ b/bin/local-start
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bundle exec falcon serve --threaded --count $CONCURRENCY --bind 'http://0.0.0.0:8080'

--- a/bin/local-unlink
+++ b/bin/local-unlink
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+unlink mtgjson-import/_base/db/ &&
+unlink mtgjson-import/_base/boot.rb &&
+unlink mtgjson-import/_base/config.ru &&
+unlink mtgjson-import/_base/configuration.rb &&
+unlink mtgjson-import/_base/database.rb &&
+unlink mtgjson-import/_base/Rakefile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
       - "./_services/postgres/data/:/var/lib/postgresql/data/"
       - "./_services/postgres/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d/"
     environment:
+      DATABASE_URL: "postgresql://postgres:password@0.0.0.0/"
       POSTGRES_PASSWORD: "password"
     logging:
       options:
@@ -41,7 +42,7 @@ services:
       POSTGRES_URI: "postgresql:///resources"
       POSTGRES_HOST: "postgres"
       POSTGRES_USERNAME: "application"
-      POSTGRES_PASSWORD: "password"
+      POSTGRES_PASSWORD: ""
       VERSION: "1"
       DEPLOY_ENV: "development"
       RACK_ENV: "development"


### PR DESCRIPTION
  - Add local environment variables
  - Database related rake tasks were failing due to not having required configurations
  - Simplified our database setup so it works on compose and gitpod
  - Made a local set of development command in case docker isn't an option
  - Create an easy server command for local development
  - Ignore any symlinks created by the above development commands
  - Allow us to unlink for teardown